### PR TITLE
Add Tailwind and lucide-react dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "lucide-react": "^0.379.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -22,6 +23,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add `lucide-react` to dependencies
- install Tailwind related dev dependencies
- create a default `tailwind.config.js`
- attempt `npx tailwindcss init` (fails in the environment)

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tailwindcss init` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684430d50ea08333a1a00a5c4901f4d0