### PR TITLE
Add basic Express server with PostgreSQL route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Server Setup
+
+The project includes a small Express server located in the `server/` directory. Use `npm run server` to start it.
+
+### Database configuration
+
+The server expects PostgreSQL credentials to be provided via environment variables:
+
+- `PGHOST`
+- `PGPORT`
+- `PGUSER`
+- `PGPASSWORD`
+- `PGDATABASE`
+
+Create a `.env` file or export these variables in your shell before starting the server.
+

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "lucide-react": "^0.379.0"
+    "lucide-react": "^0.379.0",
+    "express": "^4.19.2",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import { Pool } from 'pg';
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+
+const pool = new Pool({
+  host: process.env.PGHOST,
+  port: process.env.PGPORT,
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE,
+});
+
+app.post('/api/form', async (req, res) => {
+  const { nom, prenom, adresse, email, telephone, dateCreation } = req.body;
+
+  try {
+    await pool.query(
+      `INSERT INTO contacts (nom, prenom, adresse, email, telephone, date_creation)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [nom, prenom, adresse, email, telephone, dateCreation]
+    );
+    res.status(201).json({ message: 'Data inserted' });
+  } catch (error) {
+    console.error('Error inserting data:', error);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add express server with `/api/form` POST route
- configure server start script and dependencies
- document database environment variables in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684434f0d49c8333b3614801fe34f415