### PR TITLE
Ignore environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env
+.env.*


### PR DESCRIPTION
## Summary
- keep `.env` files out of version control

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*

------
https://chatgpt.com/codex/tasks/task_e_68443acdda7c8333a88c149f9ca0304a