### PR TITLE
Add CORS support to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^19.1.0",
     "lucide-react": "^0.379.0",
     "express": "^4.19.2",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,12 @@
 import express from 'express';
+import cors from 'cors';
 import { Pool } from 'pg';
 
 const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(express.json());
+app.use(cors());
 
 const pool = new Pool({
   host: process.env.PGHOST,


### PR DESCRIPTION
## Summary
- install cors middleware for express
- wire up cors in `server/index.js` before routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install cors --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684446c13174833398fcc1843015230c