### PR TITLE
Add dotenv support for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The server expects PostgreSQL credentials to be provided via environment variabl
 - `PGDATABASE`
 
 Create a `.env` file or export these variables in your shell before starting the server.
+The backend now uses `dotenv` to automatically load variables from a `.env` file during local development.
 
 ### Creating the contacts table
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.379.0",
     "express": "^4.19.2",
     "pg": "^8.11.5",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,9 @@
+import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import { Pool } from 'pg';
+
+dotenv.config();
 
 const app = express();
 const port = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- add `dotenv` dependency
- configure Express server to load environment variables
- document the dotenv loading behavior in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844ca7f7f208333850f9b56f276a123