### PR TITLE
Configure Vite proxy for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,29 @@ Make sure the following are installed before working with this project:
 
 ## Getting started
 
-Install dependencies and launch the project:
+Install dependencies first:
 
 ```bash
 npm install
-npm run dev      # start the Vite dev server
-npm run server   # start the Express backend
 ```
+
+### Running the project
+
+Start the backend API in one terminal:
+
+```bash
+npm run server
+```
+
+Then start the frontend in another terminal:
+
+```bash
+npm run dev
+```
+
+The Vite dev server proxies requests beginning with `/api` to
+`http://localhost:3001`, allowing the React application to communicate with
+the Express backend during development.
 
 ## Expanding the ESLint configuration
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- forward `/api` requests from Vite dev server to the Express backend
- clarify how to run both servers in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbdbf2888333a64dc2117f88e9db